### PR TITLE
Mark compatible with WordPress 7.1

### DIFF
--- a/block-minimap.php
+++ b/block-minimap.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Block Minimap
  * Plugin URI:        https://github.com/adamsilverstein/minimap
  * Description:       A Block minimap for the WordPress block editor (Gutenberg).
- * Version:           1.0.0
+ * Version:           1.0.1
  * Requires at least: 5.0
  * Requires PHP:      5.6
  * Author:            adamsilverstein

--- a/block-minimap.php
+++ b/block-minimap.php
@@ -24,8 +24,8 @@ function gcm_block_enqueue_scripts() {
 	wp_enqueue_script(
 		'minimap',
 		plugin_dir_url( __FILE__ ) . 'dist/minimap.js',
-		array(  ),
-		'',
+		array( 'lodash', 'wp-components', 'wp-data', 'wp-edit-post', 'wp-element', 'wp-i18n', 'wp-plugins' ),
+		'1.0.1',
 		true
 	);
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors:  adamsilverstein
 Tags: Minimap, mini-map, Gutenberg, Block, block editor
 Requires at least: 5.0
-Tested up to: 5.3
+Tested up to: 7.1
 Requires PHP: 5.6
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPL-2.0
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Development takes place in the [GitHub repository](https://github.com/adamsilver
 3. Use Block Minimap!
 
 == Changelog ==
+
+= 1.0.1 =
+* Confirm compatibility with WordPress 7.1.
 
 = 1.0.0 =
 Added

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ Development takes place in the [GitHub repository](https://github.com/adamsilver
 
 = 1.0.1 =
 * Confirm compatibility with WordPress 7.1.
+* Declare the editor script dependencies (lodash, wp-components, wp-data, wp-edit-post, wp-element, wp-i18n, wp-plugins). Without them the minimap failed to load with "lodash is not defined".
 
 = 1.0.0 =
 Added


### PR DESCRIPTION
_Claude chased this down, here is where it landed:_

Bumps `Tested up to` to 7.1 and cuts 1.0.1 so the update reaches the plugin directory.

Testing against 7.1 showed the plugin was flat-out broken, so that is fixed here too. The editor script died on load with:

```
Uncaught ReferenceError: lodash is not defined
```

`src/minimap.js` reads `const { debounce, map } = lodash;` and the script is enqueued with an empty dependency array, so it only ever worked because the editor happened to load lodash for its own reasons. Core no longer pulls lodash into the editor bundle, so nothing enqueued it, the script threw, and the sidebar never registered at all.

`lodash` is still registered in core 7.1, so declaring the dependencies is enough &mdash; no rewrite needed. The other `wp.*` globals the script relies on (`wp-components`, `wp-data`, `wp-edit-post`, `wp-element`, `wp-i18n`, `wp-plugins`) were undeclared for the same reason and are now listed too. The empty version string is replaced with the plugin version so the file cache-busts on release.

### Testing

Verified against WordPress 7.1-RC3 in wp-env on PHP 8.3, with `WP_DEBUG` on and this plugin the only one active:

- Before the fix: `lodash is not defined` thrown on every editor load, reproducible.
- After the fix: editor loads with no JavaScript console or page errors and a clean `debug.log`, and `wp.plugins.getPlugins()` now lists `block-minimap`, confirming the sidebar registers.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
